### PR TITLE
Remove unused NUnit import from DeckPanelManager

### DIFF
--- a/Assets/_Scripts/_InGameScene/Manager/DeckPanelManager.cs
+++ b/Assets/_Scripts/_InGameScene/Manager/DeckPanelManager.cs
@@ -1,4 +1,3 @@
-using NUnit.Framework;
 using System.Collections.Generic;
 using UnityEngine;
 


### PR DESCRIPTION
## Summary

Removes the unused `NUnit.Framework` import from `DeckPanelManager.cs`.

This resolves the review autofix without changing runtime behavior.

## Validation

- `git diff --check`
- Confirmed no `using NUnit.Framework` directives remain in runtime C# sources.
- Unity build/tests not run because Unity is unavailable in this environment.

## Review record

[LUDIARS/Castra Review/MagicChronicle/2026-07-15/AUTOFIX.md](https://github.com/LUDIARS/Castra/blob/main/Review/MagicChronicle/2026-07-15/AUTOFIX.md)